### PR TITLE
fix: corrige o erro que permitia o cadastro de cidades vazias.

### DIFF
--- a/app/src/main/java/com/example/p2/activities/NovaCidade.java
+++ b/app/src/main/java/com/example/p2/activities/NovaCidade.java
@@ -54,14 +54,18 @@ public class NovaCidade extends AppCompatActivity {
     private void salvarCidade() {
         String nome = nomeEditText.getText().toString();
         String estado = estadoEditText.getText().toString();
+        if(nome != null && estado != null){
+            Cidade novaCidade = new Cidade();
+            novaCidade.setNomeCidade(nome);
+            novaCidade.setEstado(estado);
 
-        Cidade novaCidade = new Cidade();
-        novaCidade.setNomeCidade(nome);
-        novaCidade.setEstado(estado);
-
-        db.cidadeDao().insert(novaCidade);
-        Toast.makeText(this, "Cidade salva com sucesso!", Toast.LENGTH_SHORT).show();
-        Intent intent = new Intent(NovaCidade.this, GerenciarCidades.class);
-        startActivity(intent);
+            db.cidadeDao().insert(novaCidade);
+            Toast.makeText(this, "Cidade salva com sucesso!", Toast.LENGTH_SHORT).show();
+            Intent intent = new Intent(NovaCidade.this, GerenciarCidades.class);
+            startActivity(intent);
+        }
+        else{
+            logger.error("Dados faltantes");
+        }
     }
 }


### PR DESCRIPTION
Este commit resolve a issue #1
Na issue é possível ver mais informações sobre o problema. Foi optado pela segunda abordagem, com o botão ativo e mensagem de erro ao tentar entrar sem os dados. 